### PR TITLE
Fix a flaky test by cleaning a polluted state.

### DIFF
--- a/tests/test_assoccomm.py
+++ b/tests/test_assoccomm.py
@@ -445,6 +445,7 @@ def test_assoc_flatten():
 
 
 def test_eq_assoccomm():
+    associative.facts.clear()
     x, y = var(), var()
 
     ac = "commassoc_op"


### PR DESCRIPTION
# What is the purpose of the change
This PR is to fix a flaky test `tests/test_assoccomm.py::test_eq_assoccomm`,  which can fail after running `tests/test_assoccomm.py::test_assoccomm_objects`, but passes when it is run in isolation.

# Reproduce the test failure
Run the following command:
```
python -m pytest tests/test_assoccomm.py::test_assoccomm_objects tests/test_assoccomm.py::test_eq_assoccomm
```
# Expected Result
`tests/test_assoccomm.py::test_eq_assoccomm` should pass after running `tests/test_assoccomm.py::test_assoccomm_objects`.

# Actual Result
```
FAILED tests/test_assoccomm.py::test_eq_assoccomm - TypeError: argument of type 'bool' is not iterable
```
# Why it fails
`facts` is not reset after running `tests/test_assoccomm.py::test_assoccomm_objects` with `bool` remaining.

# Fix
Clear `associative.facts` before `tests/test_assoccomm.py::test_eq_assoccomm`.